### PR TITLE
Add enabled() method to plugin for conditional activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ public function panel(Panel $panel): Panel
 }
 ```
 
+### Conditionally enabling the plugin
+
+You can restrict the plugin to specific environments using the `enabled()` method:
+
+```php
+use CmsMulti\FilamentClearCache\FilamentClearCachePlugin;
+use Illuminate\Support\Facades\App;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ->plugins([
+            FilamentClearCachePlugin::make()
+                ->enabled(App::environment(['local', 'staging'])),
+        ])
+}
+```
+
+When disabled, the clear cache button will not be rendered.
+
 ## Customizing
 
 Under the hood `optimize:clear` is called after clicking the trash button.

--- a/src/FilamentClearCachePlugin.php
+++ b/src/FilamentClearCachePlugin.php
@@ -17,6 +17,8 @@ class FilamentClearCachePlugin implements Plugin
 
     const VERSION = '3.0.0';
 
+    protected bool $enabled = true;
+
     public static function make(): static
     {
         return app(static::class);
@@ -27,8 +29,23 @@ class FilamentClearCachePlugin implements Plugin
         return static::ID;
     }
 
+    public function enabled(bool $enabled = true): static
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
     public function register(Panel $panel): void
     {
+        if (! $this->enabled) {
+            return;
+        }
         $component = config('filament-clear-cache.livewireComponentClass', ClearCache::class);
 
         if (self::isLivewireV3()) {
@@ -46,6 +63,9 @@ class FilamentClearCachePlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
+        if (! $this->enabled) {
+            return;
+        }
         if (! self::isLivewireV3()) {
             Livewire::addNamespace(
                 namespace: 'filament-clear-cache',


### PR DESCRIPTION
Allows restricting the plugin to specific environments, e.g.: ->enabled(App::environment(['local', 'staging']))