### PR TITLE
[codex] Hide clear cache button on simple pages

### DIFF
--- a/src/FilamentClearCachePlugin.php
+++ b/src/FilamentClearCachePlugin.php
@@ -6,6 +6,8 @@ use CmsMulti\FilamentClearCache\Concerns\CanDisablePlugin;
 use CmsMulti\FilamentClearCache\Http\Livewire\ClearCache;
 use Composer\InstalledVersions;
 use Filament\Contracts\Plugin;
+use Filament\Facades\Filament;
+use Filament\Pages\SimplePage;
 use Filament\Panel;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Livewire;
@@ -20,9 +22,23 @@ class FilamentClearCachePlugin implements Plugin
 
     const VERSION = '3.0.1';
 
+    protected bool $hiddenOnSimplePages = true;
+
     public static function make(): static
     {
         return app(static::class);
+    }
+
+    public function hiddenOnSimplePages(bool $condition = true): static
+    {
+        $this->hiddenOnSimplePages = $condition;
+
+        return $this;
+    }
+
+    public function isHiddenOnSimplePages(): bool
+    {
+        return $this->hiddenOnSimplePages;
     }
 
     public function getId(): string
@@ -44,10 +60,12 @@ class FilamentClearCachePlugin implements Plugin
 
         $panel->renderHook(
             name: 'panels::user-menu.before',
-            hook: fn (): string => Blade::render(
-                '@livewire($component)',
-                ['component' => $component]
-            ),
+            hook: fn (): string => $this->shouldRenderClearCacheButton()
+                ? Blade::render(
+                    '@livewire($component)',
+                    ['component' => $component]
+                )
+                : '',
         );
     }
 
@@ -70,5 +88,30 @@ class FilamentClearCachePlugin implements Plugin
         $version = InstalledVersions::getVersion('livewire/livewire');
 
         return version_compare($version, '4.0.0', '<');
+    }
+
+    private function shouldRenderClearCacheButton(): bool
+    {
+        if (! Filament::auth()->check()) {
+            return false;
+        }
+
+        if (! $this->isHiddenOnSimplePages()) {
+            return true;
+        }
+
+        $routeAction = request()->route()?->getActionName();
+
+        if (! is_string($routeAction) || $routeAction === 'Closure') {
+            return true;
+        }
+
+        $routeClass = str($routeAction)->before('@')->toString();
+
+        if (! class_exists($routeClass)) {
+            return true;
+        }
+
+        return ! is_subclass_of($routeClass, SimplePage::class);
     }
 }

--- a/tests/Unit/FilamentClearCachePluginTest.php
+++ b/tests/Unit/FilamentClearCachePluginTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Route;
 class FilamentClearCachePluginTestSimplePage extends SimplePage {}
 
 it('does not register panel hooks when disabled', function () {
-    $panel = \Mockery::mock(Panel::class);
+    $panel = Mockery::mock(Panel::class);
     $panel->shouldNotReceive('renderHook');
 
     FilamentClearCachePlugin::make()
@@ -50,7 +50,7 @@ it('can render the clear cache button on simple pages when enabled', function ()
 
     Blade::shouldReceive('render')
         ->once()
-        ->with('@livewire($component)', \Mockery::type('array'))
+        ->with('@livewire($component)', Mockery::type('array'))
         ->andReturn('clear-cache-button');
 
     expect($hook())->toBe('clear-cache-button');
@@ -64,14 +64,14 @@ it('renders the clear cache button on non-simple pages', function () {
 
     Blade::shouldReceive('render')
         ->once()
-        ->with('@livewire($component)', \Mockery::type('array'))
+        ->with('@livewire($component)', Mockery::type('array'))
         ->andReturn('clear-cache-button');
 
     expect($hook())->toBe('clear-cache-button');
 });
 
 it('no-ops during boot when disabled', function () {
-    $panel = \Mockery::mock(Panel::class);
+    $panel = Mockery::mock(Panel::class);
 
     expect(fn () => FilamentClearCachePlugin::make()
         ->enabled(false)
@@ -82,11 +82,11 @@ it('no-ops during boot when disabled', function () {
 function captureClearCacheRenderHook(?FilamentClearCachePlugin $plugin = null): Closure
 {
     $hook = null;
-    $panel = \Mockery::mock(Panel::class);
+    $panel = Mockery::mock(Panel::class);
     $panel
         ->shouldReceive('renderHook')
         ->once()
-        ->with('panels::user-menu.before', \Mockery::on(function (Closure $renderHook) use (&$hook): bool {
+        ->with('panels::user-menu.before', Mockery::on(function (Closure $renderHook) use (&$hook): bool {
             $hook = $renderHook;
 
             return true;

--- a/tests/Unit/FilamentClearCachePluginTest.php
+++ b/tests/Unit/FilamentClearCachePluginTest.php
@@ -1,11 +1,17 @@
 <?php
 
 use CmsMulti\FilamentClearCache\FilamentClearCachePlugin;
+use CmsMulti\FilamentClearCache\Tests\Models\User;
+use Filament\Pages\Dashboard;
+use Filament\Pages\SimplePage;
 use Filament\Panel;
-use Mockery;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+
+class FilamentClearCachePluginTestSimplePage extends SimplePage {}
 
 it('does not register panel hooks when disabled', function () {
-    $panel = Mockery::mock(Panel::class);
+    $panel = \Mockery::mock(Panel::class);
     $panel->shouldNotReceive('renderHook');
 
     FilamentClearCachePlugin::make()
@@ -15,11 +21,94 @@ it('does not register panel hooks when disabled', function () {
     expect(true)->toBeTrue();
 });
 
+it('does not render the clear cache button when unauthenticated', function () {
+    $hook = captureClearCacheRenderHook();
+
+    Blade::shouldReceive('render')->never();
+
+    expect($hook())->toBe('');
+});
+
+it('does not render the clear cache button on simple pages', function () {
+    $hook = captureClearCacheRenderHook();
+
+    $this->actingAs(createClearCacheUser());
+    setClearCacheRouteAction(FilamentClearCachePluginTestSimplePage::class);
+
+    Blade::shouldReceive('render')->never();
+
+    expect($hook())->toBe('');
+});
+
+it('can render the clear cache button on simple pages when enabled', function () {
+    $hook = captureClearCacheRenderHook(
+        FilamentClearCachePlugin::make()->hiddenOnSimplePages(false),
+    );
+
+    $this->actingAs(createClearCacheUser());
+    setClearCacheRouteAction(FilamentClearCachePluginTestSimplePage::class);
+
+    Blade::shouldReceive('render')
+        ->once()
+        ->with('@livewire($component)', \Mockery::type('array'))
+        ->andReturn('clear-cache-button');
+
+    expect($hook())->toBe('clear-cache-button');
+});
+
+it('renders the clear cache button on non-simple pages', function () {
+    $hook = captureClearCacheRenderHook();
+
+    $this->actingAs(createClearCacheUser());
+    setClearCacheRouteAction(Dashboard::class);
+
+    Blade::shouldReceive('render')
+        ->once()
+        ->with('@livewire($component)', \Mockery::type('array'))
+        ->andReturn('clear-cache-button');
+
+    expect($hook())->toBe('clear-cache-button');
+});
+
 it('no-ops during boot when disabled', function () {
-    $panel = Mockery::mock(Panel::class);
+    $panel = \Mockery::mock(Panel::class);
 
     expect(fn () => FilamentClearCachePlugin::make()
         ->enabled(false)
         ->boot($panel))
         ->not->toThrow(Throwable::class);
 });
+
+function captureClearCacheRenderHook(?FilamentClearCachePlugin $plugin = null): Closure
+{
+    $hook = null;
+    $panel = \Mockery::mock(Panel::class);
+    $panel
+        ->shouldReceive('renderHook')
+        ->once()
+        ->with('panels::user-menu.before', \Mockery::on(function (Closure $renderHook) use (&$hook): bool {
+            $hook = $renderHook;
+
+            return true;
+        }))
+        ->andReturnSelf();
+
+    ($plugin ?? FilamentClearCachePlugin::make())->register($panel);
+
+    return $hook;
+}
+
+function createClearCacheUser(): User
+{
+    return User::create([
+        'name' => 'John',
+        'email' => 'test@test.com',
+    ]);
+}
+
+function setClearCacheRouteAction(string $action): void
+{
+    $route = Route::get('/clear-cache-test-route', $action);
+
+    request()->setRouteResolver(fn () => $route);
+}


### PR DESCRIPTION
## Summary
- skip rendering the clear-cache Livewire button when the current Filament route is unauthenticated or a SimplePage
- add hiddenOnSimplePages(false) as an opt-out for panels that still want the button on simple pages
- cover unauthenticated, simple-page, opt-out, and normal dashboard rendering behavior

## Root cause
The package registers its button globally on panels::user-menu.before. Filament simple/auth pages can render the simple user menu area, so the hook could place the trash icon in the top-right of auth and required MFA setup flows.

## Validation
- vendor/bin/pint --dirty --format agent
- composer test -- --filter=FilamentClearCachePluginTest
- composer test